### PR TITLE
feat: Add maximo MacBook Pro configuration

### DIFF
--- a/homes/aarch64-darwin/aodhan@maximo/default.nix
+++ b/homes/aarch64-darwin/aodhan@maximo/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib.modernage;
+{
+  modernage = {
+    user = {
+      enable = true;
+      name = "aodhan";
+    };
+
+    apps = {
+      ghostty = enabled;
+    };
+
+    cli-apps = {
+      ast-grep = enabled;
+      autojump = enabled;
+      awscli = enabled;
+      bat = enabled;
+      claude-code = enabled;
+      dog = enabled;
+      entr = enabled;
+      eza = enabled;
+      fd = enabled;
+      fzf = enabled;
+      gemini-cli = enabled;
+      gh = enabled;
+      home-manager = enabled;
+      jq = enabled;
+      neovim = enabled;
+      opencode = enabled;
+      password-store = enabled;
+      pulumi = enabled;
+      ripgrep = enabled;
+      tealdeer = enabled;
+      yq = enabled;
+      zsh = enabled;
+    };
+
+    tools = {
+      devenv = enabled;
+      direnv = enabled;
+      git = enabled;
+      mcp-servers = enabled;
+      sops = enabled;
+      tmux = enabled;
+      bun = enabled;
+    };
+  };
+
+  home.stateVersion = "22.11";
+}

--- a/systems/aarch64-darwin/maximo/default.nix
+++ b/systems/aarch64-darwin/maximo/default.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  channel,
+  ...
+}:
+with lib;
+with lib.modernage;
+{
+  modernage = {
+    user = {
+      name = "ahayter";
+      uid = 502;
+    };
+
+    prototype = {
+      workstation = enabled;
+    };
+  };
+
+  # Used for backwards compatibility, please read the changelog before changing
+  # $ darwin-rebuild changelog
+  system.stateVersion = 4;
+}

--- a/systems/aarch64-darwin/maximo/default.nix
+++ b/systems/aarch64-darwin/maximo/default.nix
@@ -16,6 +16,10 @@ with lib.modernage;
     prototype = {
       workstation = enabled;
     };
+
+    services = {
+      tailscale = enabled;
+    };
   };
 
   # Used for backwards compatibility, please read the changelog before changing

--- a/systems/aarch64-darwin/maximo/default.nix
+++ b/systems/aarch64-darwin/maximo/default.nix
@@ -10,8 +10,7 @@ with lib.modernage;
 {
   modernage = {
     user = {
-      name = "ahayter";
-      uid = 502;
+      name = "aodhan";
     };
 
     prototype = {


### PR DESCRIPTION
Add new aarch64-darwin system configuration for maximo MacBook Pro.
Configuration mirrors ahayter-mbp setup with the same user settings
and workstation prototype enabled.