### PR TITLE
hunk: add cli-apps module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,6 +62,31 @@
         "url": "ssh://git@github.com/AodhanHayter/berkeley-mono-nix"
       }
     },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "hunk",
+          "nixpkgs"
+        ],
+        "systems": "systems_5",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "caveman": {
       "flake": false,
       "locked": {
@@ -435,6 +460,24 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
         "lastModified": 1772408722,
         "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
@@ -523,7 +566,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -626,6 +669,42 @@
         "type": "github"
       }
     },
+    "hunk": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783025191,
+        "narHash": "sha256-e4WwBfONdHAclbntfEVsK24Joyl3ng5zeZb38XcqB3Y=",
+        "owner": "modem-dev",
+        "repo": "hunk",
+        "rev": "1a628428678e590d69f368f59e527955c2756549",
+        "type": "github"
+      },
+      "original": {
+        "owner": "modem-dev",
+        "repo": "hunk",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "mattpocock-skills": {
       "flake": false,
       "locked": {
@@ -685,9 +764,9 @@
     },
     "nixd": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": "nixpkgs_3",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1773634079,
@@ -804,6 +883,21 @@
       }
     },
     "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1772328832,
         "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
@@ -976,6 +1070,7 @@
         "ghostty": "ghostty",
         "herdr-skill": "herdr-skill",
         "home-manager": "home-manager",
+        "hunk": "hunk",
         "mattpocock-skills": "mattpocock-skills",
         "mcp-servers-nix": "mcp-servers-nix",
         "nixd": "nixd",
@@ -1105,7 +1200,44 @@
         "type": "github"
       }
     },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hunk",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixd",

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    hunk = {
+      url = "github:modem-dev/hunk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Claude Code plugins/skills sources
     anthropics-skills = {
       url = "github:anthropics/skills";

--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,7 @@
 
       homes.modules = with inputs; [
         sops-nix.homeManagerModules.sops
+        hunk.homeManagerModules.default
         # home-manager(master) defaults home.shell.enableNushellIntegration to true;
         # nushell unused here and pinned fzf < 0.73.0 trips its integration assertion.
         { home.shell.enableNushellIntegration = false; }

--- a/homes/aarch64-darwin/ahayter@ahayter-mbp/default.nix
+++ b/homes/aarch64-darwin/ahayter@ahayter-mbp/default.nix
@@ -39,6 +39,7 @@ with lib.modernage;
       gemini-cli = disabled;
       gh = enabled;
       home-manager = enabled;
+      hunk = enabled;
       jq = enabled;
       neovim = enabled;
       opencode = enabled;

--- a/homes/aarch64-darwin/aodhan@maximo/default.nix
+++ b/homes/aarch64-darwin/aodhan@maximo/default.nix
@@ -35,6 +35,7 @@ with lib.modernage;
       gh = enabled;
       gogcli = enabled;
       home-manager = enabled;
+      hunk = enabled;
       jq = enabled;
       neovim = enabled;
       opencode = enabled;

--- a/homes/aarch64-darwin/aodhanhayter@mac-mini/default.nix
+++ b/homes/aarch64-darwin/aodhanhayter@mac-mini/default.nix
@@ -33,6 +33,7 @@ with lib.modernage;
       fzf = enabled;
       gh = enabled;
       home-manager = enabled;
+      hunk = enabled;
       jq = enabled;
       neovim = enabled;
       opencode = enabled;

--- a/homes/x86_64-linux/aodhan@ultimo/default.nix
+++ b/homes/x86_64-linux/aodhan@ultimo/default.nix
@@ -41,6 +41,7 @@ with lib.modernage;
       gh = enabled;
       gogcli = enabled;
       home-manager = enabled;
+      hunk = enabled;
       jq = enabled;
       neovim = enabled;
       opencode = enabled;

--- a/modules/home/cli-apps/hunk/default.nix
+++ b/modules/home/cli-apps/hunk/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
+with lib;
+with lib.modernage;
+let
+  cfg = config.modernage.cli-apps.hunk;
+in
+{
+  options.modernage.cli-apps.hunk = {
+    enable = mkBoolOpt false "Whether or not to install hunk.";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ inputs.hunk.packages.${pkgs.stdenv.hostPlatform.system}.hunk ];
+  };
+}

--- a/modules/home/cli-apps/hunk/default.nix
+++ b/modules/home/cli-apps/hunk/default.nix
@@ -16,6 +16,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ inputs.hunk.packages.${pkgs.stdenv.hostPlatform.system}.hunk ];
+    programs.hunk = {
+      enable = true;
+      package = inputs.hunk.packages.${pkgs.stdenv.hostPlatform.system}.hunk;
+      enableGitIntegration = true;
+    };
   };
 }

--- a/modules/home/tools/git/default.nix
+++ b/modules/home/tools/git/default.nix
@@ -114,7 +114,8 @@ in
 
     programs.diff-so-fancy = {
       enable = true;
-      enableGitIntegration = true;
+      # hunk provides the git pager (modernage.cli-apps.hunk)
+      enableGitIntegration = false;
     };
   };
 }


### PR DESCRIPTION
Add [hunk](https://github.com/modem-dev/hunk) diff viewer.

- flake input `hunk` (nixpkgs follows)
- upstream `homeManagerModules.default` imported for all homes
- `modernage.cli-apps.hunk` enables `programs.hunk` with git integration (hunk becomes git pager)
- diff-so-fancy git integration flipped off (was setting `core.pager`, conflicts with hunk); binary still installed
- enabled in all 4 homes

Verified: `nix eval` on maximo shows `core.pager = "hunk pager"` and `hunkdiff-0.16.0` in home.packages; package builds + runs on aarch64-darwin. `aodhan@ultimo` eval still fails on pre-existing `home.stateVersion` issue (unrelated). Note: upstream `meta.mainProgram` is `hunkdiff` so `nix run` fails; PATH install unaffected.